### PR TITLE
Use dedicated ServiceAccount, nexus-operator-sa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ uninstall: kustomize
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build --load_restrictor none config/${OVERLAY} | kubectl apply -f -
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/${OVERLAY} | kubectl apply -f -
 
 # Undeploy controller in the configured Kubernetes cluster in ~/.kube/config
 undeploy: kustomize
-	$(KUSTOMIZE) build --load_restrictor none config/${OVERLAY} | kubectl delete -f -
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/${OVERLAY} | kubectl delete -f -
 
 # Build the docker image
 docker-build:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,3 +48,4 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
       terminationGracePeriodSeconds: 10
+      serviceAccountName: sa

--- a/config/rbac/cluster_role_binding.yaml
+++ b/config/rbac/cluster_role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- service_account.yaml
 - cluster_role.yaml
 - cluster_role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/namespaced/kustomization.yaml
+++ b/config/rbac/namespaced/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- ../service_account.yaml
 - role.yaml
 - role_binding.yaml
 - ../leader_election_role.yaml

--- a/config/rbac/namespaced/role_binding.yaml
+++ b/config/rbac/namespaced/role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa

--- a/hack/operate.conf
+++ b/hack/operate.conf
@@ -1,5 +1,5 @@
 IMG=quay.io/redhatgov/nexus-operator
 KIND=Nexus
 CR_SAMPLE=redhatgov_v1alpha1_nexus_openshift.yaml
-VERSION=0.0.9
+VERSION=0.0.10
 CHANNELS=alpha

--- a/hack/operate.sh
+++ b/hack/operate.sh
@@ -435,7 +435,7 @@ function publish_bundle() {
     error_run "Adding namespaced Role to kustomization" 'kustomize edit add resource namespaced/role.yaml' || return 1
     error_run "Adding namespaced RoleBinding to kustomization" 'kustomize edit add resource namespaced/role_binding.yaml' || return 1
     popd &>/dev/null
-    error_run "Building bundle manifests" 'kustomize build --load_restrictor none config/manifests | operator-sdk generate bundle --overwrite --version $VERSION --channels "$CHANNELS"' || return 1
+    error_run "Building bundle manifests" 'kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle --overwrite --version $VERSION --channels "$CHANNELS"' || return 1
     error_run "Validating bundle" operator-sdk bundle validate ./bundle || return 1
     error_run "Building bundle image" docker build -f bundle.Dockerfile -t "$IMG-bundle:$VERSION" . || return 1
     if [ -z "$DEVELOP" ]; then

--- a/molecule/default/kustomize.yml
+++ b/molecule/default/kustomize.yml
@@ -1,7 +1,7 @@
 ---
 - name: Build kustomize testing overlay
-  # load_restrictor must be set to none so we can load patch files from the default overlay
-  command: '{{ kustomize }} build  --load_restrictor none .'
+  # load-restrictor must be set to none so we can load patch files from the default overlay
+  command: '{{ kustomize }} build  --load-restrictor LoadRestrictionsNone .'
   args:
     chdir: '{{ config_dir }}/testing/{{ scope|default("cluster") }}_scope'
   register: resources


### PR DESCRIPTION
This prevents conflicts in later versions of OLM where two Operators in the same namespace attempt to use the default service account.