### PR TITLE
Extract JVM memory from deployment

### DIFF
--- a/config/crd/bases/redhatgov.io_nexus.yaml
+++ b/config/crd/bases/redhatgov.io_nexus.yaml
@@ -147,6 +147,15 @@ spec:
                             description: How much memory, measured in bytes, should Nexus be limited to
                             type: string
                             pattern: ^[0-9]+[EPTGMK]?i?$
+                  jvm:
+                    description: Defines the JVM parameters
+                    type: object
+                    properties:
+                      memory:
+                        description: |
+                          How much memory, measured in bytes, should the JVM allocate
+                        type: string
+                        pattern: ^[0-9]+[gmk]?$
           status:
             description: Status defines the observed state of Nexus
             type: object

--- a/develop/operate.conf
+++ b/develop/operate.conf
@@ -1,5 +1,5 @@
 IMG=quay.io/redhatgov/nexus-operator
 KIND=Nexus
 CR_SAMPLE=redhatgov_v1alpha1_nexus_openshift.yaml
-VERSION=0.0.10
+VERSION=0.0.11
 CHANNELS=alpha

--- a/playbooks/nexus-operator.yml
+++ b/playbooks/nexus-operator.yml
@@ -36,3 +36,5 @@
       _nexus_memory_limit: "{{ nexus.resources.memory.limit | default('3Gi') }}"
       _nexus_cpu_request: "{{ nexus.resources.cpu.request | default(1) }}"
       _nexus_cpu_limit: "{{ nexus.resources.cpu.limit | default(4) }}"
+      
+      _nexus_jvm_memory: "{{ nexus.jvm.memory | default('512m') }}"

--- a/roles/nexus-ocp/README.adoc
+++ b/roles/nexus-ocp/README.adoc
@@ -25,6 +25,7 @@ This role is designed to set up Nexus Repository Manager on an OpenShift or Kube
 |_nexus_expose_method           |Route                        |No           |Options include `Route`, `Ingress`, and `None`
 |_nexus_expose_uri              |""                           |No           |The URI to expose via Route/Ingress.
 |_nexus_ssl                     |True                         |No           |Set up HTTPS for the Nexus Route/Ingress
+|_nexus_jvm_memory              |512m                         |No           |Memory allocated for the JVM
 |====
 
 == Dependencies

--- a/roles/nexus-ocp/defaults/main.yml
+++ b/roles/nexus-ocp/defaults/main.yml
@@ -22,3 +22,5 @@ _nexus_expose_uri: ""
 _nexus_oauth: True
 _nexus_route: "{{ _nexus_expose_uri }}"
 _nexus_ssl: True
+
+_nexus_jvm_memory: 512m

--- a/roles/nexus-ocp/templates/deployment.yml.j2
+++ b/roles/nexus-ocp/templates/deployment.yml.j2
@@ -90,7 +90,7 @@ spec:
             memory: "{{ _nexus_memory_limit }}"
         env:
         - name: INSTALL4J_ADD_VM_PARAMS
-          value: -Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs
+          value: -Xms{{ _nexus_jvm_memory }} -Xmx{{ _nexus_jvm_memory }} -XX:MaxDirectMemorySize={{ _nexus_jvm_memory }} -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs
         volumeMounts:
         - name: nexus-data
           mountPath: /nexus-data


### PR DESCRIPTION
Extracts the JVM memory settings into a field in the CRD so that the amount of JVM memory can be configured along with the Pod's and avoid situations where the default value of 256m throughs an OOM error.
